### PR TITLE
fix: don't award san ankou for a ron-completed triplet via open chi

### DIFF
--- a/crates/agari-core/src/hand.rs
+++ b/crates/agari-core/src/hand.rs
@@ -400,6 +400,40 @@ pub fn is_winning_hand(counts: &TileCounts) -> bool {
     check_kokushi(counts).is_some() || is_chiitoitsu(counts) || is_standard_hand(counts)
 }
 
+/// Whether the winning tile is part of a concealed (closed) sequence in the hand.
+///
+/// Only closed sequences count. An open called sequence (chi) was completed turns
+/// before the win, so the winning tile can never be the tile that completed it. This
+/// distinguishes a genuine multi-way wait (the winning tile could finish a concealed
+/// sequence instead of a same-value triplet, leaving that triplet concealed) from a
+/// triplet that was truly completed by the winning tile.
+pub(crate) fn winning_tile_in_closed_sequence(tile: Tile, melds: &[Meld]) -> bool {
+    // Honor tiles can never be part of a sequence.
+    let (suit, value) = match tile {
+        Tile::Suited { suit, value } => (suit, value),
+        Tile::Honor(_) => return false,
+    };
+
+    for meld in melds {
+        if let Meld::Shuntsu(start_tile, is_open) = meld {
+            if *is_open {
+                continue; // Open called sequences were already complete before the wait.
+            }
+            if let Tile::Suited {
+                suit: seq_suit,
+                value: start_val,
+            } = start_tile
+                && *seq_suit == suit
+                && value >= *start_val
+                && value <= start_val + 2
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/agari-core/src/scoring.rs
+++ b/crates/agari-core/src/scoring.rs
@@ -9,7 +9,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::context::{GameContext, WinType};
-use crate::hand::{HandStructure, Meld};
+use crate::hand::{HandStructure, Meld, winning_tile_in_closed_sequence};
 use crate::tile::{Honor, Tile};
 use crate::wait::{best_wait_type_for_scoring, is_pinfu};
 use crate::yaku::YakuResult;
@@ -308,41 +308,6 @@ fn meld_fu_with_context(meld: &Meld, all_melds: &[Meld], context: &GameContext) 
             if kan_type.is_open() { base } else { base * 2 }
         }
     }
-}
-
-/// Check if a tile appears in any CLOSED sequence in the hand.
-/// Used to detect nobetan patterns where the winning tile could complete
-/// either a triplet or a sequence.
-///
-/// Only closed sequences count because open/called sequences were already
-/// complete before the wait - they don't represent alternative interpretations
-/// of the waiting shape.
-fn winning_tile_in_closed_sequence(tile: Tile, melds: &[Meld]) -> bool {
-    // Honor tiles can never be in sequences
-    let (suit, value) = match tile {
-        Tile::Suited { suit, value } => (suit, value),
-        Tile::Honor(_) => return false,
-    };
-
-    for meld in melds {
-        // Only check CLOSED sequences (is_open = false)
-        if let Meld::Shuntsu(start_tile, is_open) = meld {
-            if *is_open {
-                continue; // Skip open/called sequences
-            }
-            if let Tile::Suited {
-                suit: seq_suit,
-                value: start_val,
-            } = start_tile
-            {
-                // Check if tile is part of this sequence (start, start+1, start+2)
-                if *seq_suit == suit && value >= *start_val && value <= start_val + 2 {
-                    return true;
-                }
-            }
-        }
-    }
-    false
 }
 
 /// Calculate fu for a single meld (without context, used in tests)

--- a/crates/agari-core/src/yaku.rs
+++ b/crates/agari-core/src/yaku.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::context::{GameContext, WinType, count_dora_detailed};
-use crate::hand::{HandStructure, Meld};
+use crate::hand::{HandStructure, Meld, winning_tile_in_closed_sequence};
 use crate::parse::TileCounts;
 use crate::tile::{Honor, Suit, Tile};
 use crate::wait::is_pinfu;
@@ -458,35 +458,16 @@ pub fn detect_yaku_with_context(
                 // San Ankou (three concealed triplets)
                 // Note: Closed kans count as concealed triplets for san ankou
                 {
-                    // First, check if the winning tile could complete a sequence in this hand.
-                    // If it can, then triplets matching the winning tile remain concealed
-                    // (the player could have won on the sequence instead).
-                    let winning_tile_completes_sequence = if let Some(wt) = context.winning_tile {
-                        melds.iter().any(|m| {
-                            if let Meld::Shuntsu(start, _) = m {
-                                // Check if winning tile is part of this sequence
-                                if let (
-                                    Tile::Suited {
-                                        suit: ws,
-                                        value: wv,
-                                    },
-                                    Tile::Suited {
-                                        suit: ss,
-                                        value: sv,
-                                    },
-                                ) = (wt, start)
-                                {
-                                    ws == *ss && wv >= *sv && wv <= sv + 2
-                                } else {
-                                    false
-                                }
-                            } else {
-                                false
-                            }
-                        })
-                    } else {
-                        false
-                    };
+                    // A triplet completed by ron is an open meld (minko), not concealed.
+                    // It still counts toward san ankou only if the winning tile could
+                    // instead have completed a concealed sequence, in which case the
+                    // triplet was already concealed in hand. An open called sequence can
+                    // never be the group the winning tile completed, so only concealed
+                    // sequences keep the triplet concealed.
+                    let winning_tile_completes_sequence = context
+                        .winning_tile
+                        .map(|wt| winning_tile_in_closed_sequence(wt, melds))
+                        .unwrap_or(false);
 
                     let mut concealed_triplets = 0;
                     for meld in melds {
@@ -1734,6 +1715,63 @@ mod tests {
     }
 
     #[test]
+    fn san_ankou_not_awarded_when_triplet_completed_by_ron_with_open_chi() {
+        use crate::hand::decompose_hand_with_melds;
+        use crate::parse::parse_hand_with_aka;
+
+        // A triplet completed by ron is an open meld (minko), not concealed, so it
+        // does not count toward san ankou. An open called sequence can never be the
+        // group the winning tile completed, so it does not keep the triplet concealed.
+        //
+        // Hand: 111m 777m 999p 55z + open chi (678m), ron on 7m.
+        // The 7m completes 777m into a minko; the only sequence containing 7m is the
+        // open (678m) chi, melded earlier. Only 111m and 999p stay concealed -> two
+        // concealed triplets, no san ankou, and the hand is yakuless.
+        let parsed = parse_hand_with_aka("111777m999p55z(678m)").unwrap();
+        let counts = to_counts(&parsed.tiles);
+        let called_melds: Vec<_> = parsed
+            .called_melds
+            .iter()
+            .map(|cm| cm.meld.clone())
+            .collect();
+
+        let structures = decompose_hand_with_melds(&counts, &called_melds);
+        assert!(!structures.is_empty());
+
+        let context = GameContext::new(WinType::Ron, Honor::East, Honor::East)
+            .with_winning_tile(Tile::suited(Suit::Man, 7))
+            .open();
+
+        for structure in &structures {
+            let result = detect_yaku_with_context(structure, &counts, &context);
+            assert!(
+                !result.yaku_list.contains(&Yaku::SanAnkou),
+                "open chi must not keep the ron-completed triplet concealed"
+            );
+            assert!(
+                result.yaku_list.is_empty(),
+                "hand is yakuless: an open hand with no yakuhai and only two concealed triplets"
+            );
+        }
+    }
+
+    #[test]
+    fn san_ankou_awarded_when_ron_tile_also_completes_concealed_sequence() {
+        // Counterpart to the open-chi case: when the ron tile could instead complete a
+        // CONCEALED sequence, the same-value triplet was already concealed in hand, so
+        // san ankou stands. This guards against the fix over-correcting by dropping the
+        // concealed-sequence allowance entirely.
+        //
+        // Hand: 111m 222p 333s 345s 77z (fully concealed), ron on 3s.
+        // The 3s can complete the concealed 345s sequence, leaving 333s concealed.
+        let context = GameContext::new(WinType::Ron, Honor::East, Honor::East)
+            .with_winning_tile(Tile::suited(Suit::Sou, 3));
+        let results = get_yaku_with_context("111m222p333345s77z", &context);
+
+        assert!(has_yaku(&results, Yaku::SanAnkou));
+    }
+
+    #[test]
     fn test_daisuushii_closed_double_yakuman() {
         // Four wind triplets (East/South/West/North) + a suited pair (9m).
         // Win by ron completing the East triplet so the hand isn't also suuankou
@@ -1827,6 +1865,23 @@ mod tests {
             .unwrap();
         assert!(r.is_yakuman);
         assert_eq!(r.total_han, 13);
+    }
+
+    #[test]
+    fn suuankou_not_awarded_on_shanpon_ron() {
+        // Lock-in for the shared concealed-sequence predicate: a four-triplet hand has
+        // no sequences, so a shanpon ron that completes the fourth triplet opens it
+        // (minko). The hand falls back to san ankou + toitoi, not suuankou.
+        //
+        // Hand: 111m 333m 555p 777s 99s on a 7s/9s shanpon, ron on 7s.
+        let context = GameContext::new(WinType::Ron, Honor::East, Honor::East)
+            .with_winning_tile(Tile::suited(Suit::Sou, 7));
+        let results = get_yaku_with_context("111m333m555p777s99s", &context);
+
+        assert!(!has_yaku(&results, Yaku::Suuankou));
+        assert!(!has_yaku(&results, Yaku::SuuankouTanki));
+        assert!(has_yaku(&results, Yaku::SanAnkou));
+        assert!(has_yaku(&results, Yaku::Toitoi));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

An open hand could be wrongly scored **San Ankou** when the winning tile (ron) completed a triplet, as long as an **open called chi** covered that tile.

Repro:
```
agari "111777m999p55z(678m)" -w 7m
```
Before: San Ankou (2 han, 3900). The hand is open, has no yakuhai, and the `777m` triplet was completed by the ron tile (a minko, not concealed). Only `111m` and `999p` are concealed, so the hand is **yakuless and the ron is illegal**. After: no yaku, hand cannot win.

## Root cause

The san ankou check (`yaku.rs`) kept a ron-completed triplet counted as concealed whenever any sequence in the hand covered the winning tile, but it matched `Meld::Shuntsu(start, _)` and **ignored the open/closed flag**. An open called sequence was completed turns before the win and can never be the group the winning tile completed.

The fu calculation already had the correct predicate (`winning_tile_in_closed_sequence`, which skips open sequences). This PR moves that single predicate into `hand` as `pub(crate)` and uses it for **both** the san ankou check and the fu calc, so the two cannot diverge again.

## Scope

- **San Ankou:** fixed. The legitimate case, the ron tile completing a *concealed* sequence that overlaps a same-value triplet, is preserved (the triplet was already concealed in hand).
- **Suuankou:** unaffected. A four-triplet hand has no sequences, so a shanpon ron that completes the fourth triplet correctly falls back to san ankou + toitoi, and a tanki ron remains suuankou tanki. Lock-in test added.

## Tests

- `san_ankou_not_awarded_when_triplet_completed_by_ron_with_open_chi` (the exact repro)
- `san_ankou_awarded_when_ron_tile_also_completes_concealed_sequence` (don't over-correct)
- `suuankou_not_awarded_on_shanpon_ron` (yakuman lock-in)

Full `agari-core` suite green (277 lib tests), clippy clean.

## Downstream note

This is a scoring correction in a published crate. Open-chi-overlap hands that previously won a phantom San Ankou now correctly score as yakuless. Consumers pinning `agari` will see different output for these hands; worth a changelog entry and a version bump per the repo's release flow.