### PR TITLE
fix: score four identical sequences as ryanpeikou

### DIFF
--- a/crates/agari-core/src/yaku.rs
+++ b/crates/agari-core/src/yaku.rs
@@ -620,7 +620,10 @@ fn check_peikou(melds: &[Meld]) -> Option<Yaku> {
         *seq_counts.entry(*t).or_insert(0) += 1;
     }
 
-    let pairs_of_sequences = seq_counts.values().filter(|&&c| c >= 2).count();
+    // Count identical-sequence pairs, not distinct sequence types: four copies
+    // of the same sequence form two pairs (ryanpeikou), so each type contributes
+    // floor(count / 2).
+    let pairs_of_sequences: u8 = seq_counts.values().map(|&c| c / 2).sum();
 
     if pairs_of_sequences >= 2 {
         Some(Yaku::Ryanpeikou)
@@ -1183,6 +1186,15 @@ mod tests {
     #[test]
     fn test_ryanpeikou() {
         let results = get_yaku("112233m112233p55s");
+        assert!(has_yaku(&results, Yaku::Ryanpeikou));
+        assert!(!has_yaku(&results, Yaku::Iipeikou));
+    }
+
+    #[test]
+    fn test_ryanpeikou_four_identical_sequences() {
+        // Four copies of the same sequence form two identical-sequence pairs,
+        // so this is ryanpeikou, not iipeikou.
+        let results = get_yaku("777788889999m11p");
         assert!(has_yaku(&results, Yaku::Ryanpeikou));
         assert!(!has_yaku(&results, Yaku::Iipeikou));
     }


### PR DESCRIPTION
## Problem

The hand `77778888999m11p` tsumo on `9m` (final tiles: 7m x4, 8m x4, 9m x4, 1p x2) was scored as **6 han** (Tsumo + Pinfu + Iipeikou + Junchan) when it should be **8 han** with **ryanpeikou**. Reported via Reddit.

The hand decomposes as four identical `789m` sequences + `11p` pair. Four copies of the same sequence form two identical-sequence pairs, which is ryanpeikou (3 han), not iipeikou (1 han).

## Root cause

`check_peikou` counted *distinct sequence types* appearing at least twice:

```rust
let pairs_of_sequences = seq_counts.values().filter(|&&c| c >= 2).count();
```

For `789m x4`, `seq_counts = {789m: 4}`, so this counts a single type and returns iipeikou. It should count identical *pairs*.

## Fix

```rust
let pairs_of_sequences: u8 = seq_counts.values().map(|&c| c / 2).sum();
```

Per sequence type the contribution becomes floor(count / 2): `1 -> 0`, `2 -> 1`, `3 -> 1`, `4 -> 2`. Only the count-of-4 case changes behavior, so every hand that is not four identical sequences scores exactly as before. The existing two-distinct-pairs ryanpeikou path (`{123m: 2, 789m: 2}` -> `1 + 1 = 2`) is unaffected.

## Why this is safe

- `check_peikou` has a single caller, gated on closed hands, operating on a standard hand's 4 melds, so a sequence type can appear at most 4 times.
- Nothing downstream branches on iipeikou vs ryanpeikou beyond the han value and display strings (no fu, score-level, pinfu, junchan, or decomposition-selection coupling).
- The scorer evaluates every decomposition and picks the max total, so upgrading one decomposition's han can never drop another yaku.
- Four-of-a-kind held in hand cannot be a quad: kans must be declared and a four-kan hand is 18 tiles, not 14.

## Verification

- `cargo test --workspace`: all pass (core 277 -> 278 with a new regression test `test_ryanpeikou_four_identical_sequences`).
- Live: `agari "777788889999m11p" -w 9m -t` now reports Ryanpeikou, 8 han, Baiman (24000) instead of Iipeikou, 6 han, Haneman (18000).