### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0]
+
+### Fixed
+
+- **Ryanpeikou with four identical sequences**: A closed hand of four identical sequences (for example `777788889999m11p`, four `789m` sequences plus an `11p` pair) now scores ryanpeikou (3 han) instead of iipeikou (1 han). Four copies of the same sequence form two identical-sequence pairs, so the hand is ryanpeikou. The san ankou and other peikou cases are unaffected.
+
 ## [0.23.0]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agari"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "clap",
  "colored",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "agari-python"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "agari",
  "pyo3",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "agari-wasm"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "agari",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "thin"
 opt-level = "z"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 repository = "https://github.com/agari-industries/agari"
 homepage = "https://github.com/agari-industries/agari"

--- a/crates/agari-core/Cargo.toml
+++ b/crates/agari-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agari"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 repository = "https://github.com/agari-industries/agari"
 homepage = "https://github.com/agari-industries/agari"

--- a/crates/agari-wasm/Cargo.toml
+++ b/crates/agari-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agari-wasm"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 description = "WebAssembly bindings for Agari Riichi Mahjong scoring engine"
 license = "MIT"


### PR DESCRIPTION
Bump workspace version `0.23.0` -> `0.24.0` and add the 0.24.0 CHANGELOG entry.

## Included since v0.23.0

- #23 fix: score four identical sequences as ryanpeikou

## Changes

- Workspace version bump across `agari-core`, `agari-wasm`, and `agari-python` (workspace inheritance), plus `Cargo.lock`.
- New `## [0.24.0]` CHANGELOG section documenting the ryanpeikou four-identical-sequences fix.

## Verification

- `cargo test --workspace`: all pass (core 278, wasm 31 + 27).