### PR TITLE
fix(webui): align empty hand slots with filled tiles

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1769,6 +1769,9 @@
     .tile-placeholder {
         width: 40px;
         height: 56px;
+        /* Mirror the 2px transparent border on filled tiles' .tile-wrapper so
+           empty slots share the same footprint and inter-tile spacing. */
+        margin: 2px;
         border: 1px dashed var(--border);
         background: var(--bg-elevated);
     }


### PR DESCRIPTION
Empty hand slots sat slightly higher than filled tiles, and the inter-tile spacing differed between filled and empty slots.

Cause: filled tiles carry a 2px transparent border via `.tile-wrapper` (the hover/selection ring) that the bare `.tile-placeholder` lacked. With `box-sizing: border-box`, that made filled tiles a 44x60 box with the visible 40x56 tile inset 2px, while empty slots were a flat 40x56 box filling their footprint. The flex row top-aligned the shorter slots (ride-up), and the missing inset changed visible spacing.

Fix: add `margin: 2px` to `.tile-placeholder` so empty slots mirror that border. Both vertical alignment and inter-slot spacing now match across filled and empty slots. Placeholder-only CSS change.